### PR TITLE
fix: mark one-time care tasks as done when completed/skipped

### DIFF
--- a/mcp/src/api.ts
+++ b/mcp/src/api.ts
@@ -63,10 +63,11 @@ export const api = {
   createPlantReference: (data: any) => post<any>("/plants/references", data),
 
   // Care tasks
-  getCareTasks: (params?: { plantInstanceId?: number; upcoming?: boolean }) => {
+  getCareTasks: (params?: { plantInstanceId?: number; upcoming?: boolean; includeCompleted?: boolean }) => {
     const sp = new URLSearchParams();
     if (params?.plantInstanceId) sp.set("plantInstanceId", String(params.plantInstanceId));
     if (params?.upcoming) sp.set("upcoming", "true");
+    if (params?.includeCompleted) sp.set("includeCompleted", "true");
     const q = sp.toString() ? `?${sp}` : "";
     return request<any[]>(`/care-tasks${q}`);
   },

--- a/mcp/src/tools.ts
+++ b/mcp/src/tools.ts
@@ -106,13 +106,14 @@ export function registerTools(server: McpServer) {
 
   server.tool(
     "list_care_tasks",
-    "List care tasks, optionally filtered by plant or upcoming only",
+    "List active care tasks, optionally filtered by plant or upcoming only. Completed one-time tasks are excluded by default.",
     {
       plant_id: z.number().optional().describe("Filter by plant instance ID"),
       upcoming: z.boolean().optional().describe("Only show upcoming/due tasks"),
+      include_completed: z.boolean().optional().describe("Include one-time tasks that have been marked done"),
     },
-    async ({ plant_id, upcoming }) => handle(async () => {
-      const tasks = await api.getCareTasks({ plantInstanceId: plant_id, upcoming });
+    async ({ plant_id, upcoming, include_completed }) => handle(async () => {
+      const tasks = await api.getCareTasks({ plantInstanceId: plant_id, upcoming, includeCompleted: include_completed });
       const summary = tasks.map((t: any) => ({
         id: t.id,
         title: t.title,

--- a/server/drizzle/0015_care_task_completed_at.sql
+++ b/server/drizzle/0015_care_task_completed_at.sql
@@ -1,0 +1,19 @@
+ALTER TABLE `care_tasks` ADD `completed_at` text;--> statement-breakpoint
+CREATE INDEX `care_tasks_completed_at_idx` ON `care_tasks` (`completed_at`);--> statement-breakpoint
+-- Backfill: mark any non-recurring task that already has a completed or
+-- skipped log row as done, using the most recent log timestamp.
+-- Note: care_task_logs uses `completed_at` as the timestamp column name,
+-- not `created_at`.
+UPDATE `care_tasks`
+SET `completed_at` = (
+  SELECT MAX(`completed_at`) FROM `care_task_logs`
+  WHERE `care_task_logs`.`care_task_id` = `care_tasks`.`id`
+    AND `care_task_logs`.`action` IN ('completed', 'skipped')
+)
+WHERE `is_recurring` = 0
+  AND `completed_at` IS NULL
+  AND EXISTS (
+    SELECT 1 FROM `care_task_logs`
+    WHERE `care_task_logs`.`care_task_id` = `care_tasks`.`id`
+      AND `care_task_logs`.`action` IN ('completed', 'skipped')
+  );

--- a/server/drizzle/meta/_journal.json
+++ b/server/drizzle/meta/_journal.json
@@ -106,6 +106,13 @@
       "when": 1775600000000,
       "tag": "0014_api_keys",
       "breakpoints": true
+    },
+    {
+      "idx": 15,
+      "version": "6",
+      "when": 1776000000000,
+      "tag": "0015_care_task_completed_at",
+      "breakpoints": true
     }
   ]
 }

--- a/server/src/db/schema.ts
+++ b/server/src/db/schema.ts
@@ -411,6 +411,9 @@ export const careTasks = sqliteTable("care_tasks", {
   lastNotifiedAt: text("last_notified_at"),
   // Plant-POV message for notifications
   plantMessage: text("plant_message"), // "I could use a trim! 🌿"
+  // Set when a one-time (non-recurring) task is completed or skipped. Filtered
+  // out of the default list view. Recurring tasks advance dueDate instead.
+  completedAt: text("completed_at"),
   createdAt: text("created_at")
     .notNull()
     .$defaultFn(() => new Date().toISOString()),
@@ -421,6 +424,7 @@ export const careTasks = sqliteTable("care_tasks", {
   index("care_tasks_plant_instance_id_idx").on(table.plantInstanceId),
   index("care_tasks_zone_id_idx").on(table.zoneId),
   index("care_tasks_due_date_idx").on(table.dueDate),
+  index("care_tasks_completed_at_idx").on(table.completedAt),
 ]);
 
 export const careTasksRelations = relations(careTasks, ({ one, many }) => ({

--- a/server/src/routes/care-tasks.test.ts
+++ b/server/src/routes/care-tasks.test.ts
@@ -1,0 +1,207 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from "vitest";
+import Database from "better-sqlite3";
+import { drizzle } from "drizzle-orm/better-sqlite3";
+import * as schema from "../db/schema.js";
+import Fastify from "fastify";
+import { careTaskRoutes } from "./care-tasks.js";
+import type { Role } from "../plugins/auth.js";
+
+// Minimal in-memory schema — just what the route touches
+const sqlite = new Database(":memory:");
+sqlite.pragma("journal_mode = WAL");
+sqlite.pragma("foreign_keys = ON");
+sqlite.exec(`
+  CREATE TABLE care_tasks (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    plant_instance_id INTEGER,
+    zone_id INTEGER,
+    location_id INTEGER,
+    task_type TEXT NOT NULL,
+    title TEXT NOT NULL,
+    description TEXT,
+    due_date TEXT,
+    is_recurring INTEGER NOT NULL DEFAULT 0,
+    interval_days INTEGER,
+    active_months TEXT,
+    send_notification INTEGER NOT NULL DEFAULT 1,
+    last_notified_at TEXT,
+    plant_message TEXT,
+    completed_at TEXT,
+    created_at TEXT NOT NULL DEFAULT (datetime('now')),
+    updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+  );
+  CREATE TABLE care_task_logs (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    care_task_id INTEGER NOT NULL REFERENCES care_tasks(id) ON DELETE CASCADE,
+    action TEXT NOT NULL DEFAULT 'completed',
+    notes TEXT,
+    photo_id INTEGER,
+    created_by INTEGER,
+    rain_provisional INTEGER NOT NULL DEFAULT 0,
+    completed_at TEXT NOT NULL DEFAULT (datetime('now'))
+  );
+  CREATE TABLE journal_entries (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    plant_instance_id INTEGER,
+    zone_id INTEGER,
+    location_id INTEGER,
+    entry_type TEXT NOT NULL,
+    title TEXT,
+    body TEXT,
+    care_task_log_id INTEGER,
+    created_by INTEGER,
+    created_at TEXT NOT NULL DEFAULT (datetime('now')),
+    updated_at TEXT NOT NULL DEFAULT (datetime('now') || 'Z')
+  );
+  CREATE TABLE journal_photos (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    journal_entry_id INTEGER NOT NULL,
+    plant_photo_id INTEGER NOT NULL,
+    sort_order INTEGER NOT NULL DEFAULT 0
+  );
+  CREATE TABLE plant_instances (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    status TEXT NOT NULL DEFAULT 'planted'
+  );
+`);
+
+const testDb = drizzle(sqlite, { schema });
+
+import * as dbModule from "../db/index.js";
+Object.defineProperty(dbModule, "db", { value: testDb, writable: true });
+
+const app = Fastify();
+app.decorateRequest("user", null);
+app.decorateRequest("setupMode", false);
+app.addHook("onRequest", async (request) => {
+  request.user = { id: 1, username: "t", displayName: "T", role: "gardener" as Role };
+  request.setupMode = false;
+});
+
+beforeAll(async () => {
+  await app.register(careTaskRoutes, { prefix: "/api/care-tasks" });
+  await app.ready();
+});
+
+afterAll(async () => {
+  await app.close();
+  sqlite.close();
+});
+
+beforeEach(() => {
+  sqlite.exec("DELETE FROM care_task_logs; DELETE FROM journal_entries; DELETE FROM care_tasks; DELETE FROM plant_instances;");
+});
+
+function createTask(partial: {
+  title: string;
+  task_type?: string;
+  is_recurring?: number;
+  interval_days?: number | null;
+  due_date?: string | null;
+}) {
+  const r = sqlite
+    .prepare(
+      `INSERT INTO care_tasks (title, task_type, is_recurring, interval_days, due_date)
+       VALUES (?, ?, ?, ?, ?) RETURNING id`,
+    )
+    .get(
+      partial.title,
+      partial.task_type ?? "prune",
+      partial.is_recurring ?? 0,
+      partial.interval_days ?? null,
+      partial.due_date ?? "2026-04-01",
+    ) as { id: number };
+  return r.id;
+}
+
+describe("Care tasks completion", () => {
+  it("marks a one-time task completed and hides it from the default list", async () => {
+    const id = createTask({ title: "Remove pampas", is_recurring: 0 });
+
+    const logRes = await app.inject({
+      method: "POST",
+      url: `/api/care-tasks/${id}/log`,
+      payload: { action: "completed" },
+    });
+    expect(logRes.statusCode).toBe(201);
+
+    // Task should now have completedAt set
+    const row = sqlite.prepare("SELECT completed_at, is_recurring FROM care_tasks WHERE id = ?").get(id) as { completed_at: string | null; is_recurring: number };
+    expect(row.completed_at).not.toBeNull();
+
+    // Default list should not include it
+    const listRes = await app.inject({ method: "GET", url: "/api/care-tasks" });
+    expect(listRes.statusCode).toBe(200);
+    const tasks = listRes.json() as Array<{ id: number }>;
+    expect(tasks.find((t) => t.id === id)).toBeUndefined();
+  });
+
+  it("includes completed tasks when includeCompleted=true", async () => {
+    const id = createTask({ title: "Call Mt Scott Fuel", is_recurring: 0 });
+    await app.inject({
+      method: "POST",
+      url: `/api/care-tasks/${id}/log`,
+      payload: { action: "completed" },
+    });
+
+    const listRes = await app.inject({ method: "GET", url: "/api/care-tasks?includeCompleted=true" });
+    const tasks = listRes.json() as Array<{ id: number }>;
+    expect(tasks.find((t) => t.id === id)).toBeDefined();
+  });
+
+  it("also hides skipped one-time tasks from the default list", async () => {
+    const id = createTask({ title: "Skipped thing", is_recurring: 0 });
+    await app.inject({
+      method: "POST",
+      url: `/api/care-tasks/${id}/log`,
+      payload: { action: "skipped" },
+    });
+
+    const listRes = await app.inject({ method: "GET", url: "/api/care-tasks" });
+    const tasks = listRes.json() as Array<{ id: number }>;
+    expect(tasks.find((t) => t.id === id)).toBeUndefined();
+  });
+
+  it("keeps a recurring task visible after completion (advances due date)", async () => {
+    const id = createTask({
+      title: "Weekly watering",
+      is_recurring: 1,
+      interval_days: 7,
+      due_date: "2026-01-01",
+    });
+
+    await app.inject({
+      method: "POST",
+      url: `/api/care-tasks/${id}/log`,
+      payload: { action: "completed" },
+    });
+
+    const row = sqlite
+      .prepare("SELECT completed_at, due_date FROM care_tasks WHERE id = ?")
+      .get(id) as { completed_at: string | null; due_date: string };
+    expect(row.completed_at).toBeNull();
+    expect(row.due_date).not.toBe("2026-01-01"); // advanced
+
+    const listRes = await app.inject({ method: "GET", url: "/api/care-tasks" });
+    const tasks = listRes.json() as Array<{ id: number }>;
+    expect(tasks.find((t) => t.id === id)).toBeDefined();
+  });
+
+  it("hides one-time tasks via bulk log completion", async () => {
+    const ids = [
+      createTask({ title: "Task A", is_recurring: 0 }),
+      createTask({ title: "Task B", is_recurring: 0 }),
+    ];
+
+    await app.inject({
+      method: "POST",
+      url: "/api/care-tasks/bulk/log",
+      payload: { ids, action: "completed" },
+    });
+
+    const listRes = await app.inject({ method: "GET", url: "/api/care-tasks" });
+    const tasks = listRes.json() as Array<{ id: number }>;
+    expect(tasks.find((t) => t.id === ids[0])).toBeUndefined();
+    expect(tasks.find((t) => t.id === ids[1])).toBeUndefined();
+  });
+});

--- a/server/src/routes/care-tasks.ts
+++ b/server/src/routes/care-tasks.ts
@@ -47,11 +47,12 @@ export async function careTaskRoutes(app: FastifyInstance) {
       zoneId?: string;
       locationId?: string;
       upcoming?: string;
+      includeCompleted?: string;
       page?: string;
       limit?: string;
     };
   }>("/", async (request) => {
-    const { plantInstanceId, zoneId, locationId, upcoming } = request.query;
+    const { plantInstanceId, zoneId, locationId, upcoming, includeCompleted } = request.query;
     const pagination = parsePagination(request.query);
 
     const conditions = [];
@@ -72,6 +73,12 @@ export async function careTaskRoutes(app: FastifyInstance) {
       conditions.push(
         sql`${careTasks.dueDate} >= date('now')`,
       );
+    }
+
+    // By default hide tasks that have been completed (one-time tasks marked done).
+    // Pass ?includeCompleted=true to include them.
+    if (includeCompleted !== "true") {
+      conditions.push(sql`${careTasks.completedAt} IS NULL`);
     }
 
     // Add status filter: exclude tasks for planned/dead/removed plants
@@ -261,14 +268,9 @@ export async function careTaskRoutes(app: FastifyInstance) {
       }
     }
 
-    // If recurring and completed, advance the due date
-    if (
-      bodyParsed.data.action === "completed" &&
-      existing.isRecurring &&
-      existing.intervalDays &&
-      existing.dueDate
-    ) {
-      // Advance from today if overdue, otherwise from the original due date
+    if (bodyParsed.data.action === "completed" && existing.isRecurring && existing.intervalDays && existing.dueDate) {
+      // Recurring completion: advance the due date from today if overdue,
+      // otherwise from the original due date. The task stays active.
       const baseDate = new Date(existing.dueDate) < new Date() ? new Date() : new Date(existing.dueDate);
       const nextDue = new Date(baseDate);
       nextDue.setDate(nextDue.getDate() + existing.intervalDays);
@@ -277,6 +279,16 @@ export async function careTaskRoutes(app: FastifyInstance) {
           dueDate: nextDue.toISOString().split("T")[0],
           updatedAt: new Date().toISOString(),
         })
+        .where(eq(careTasks.id, careTaskId))
+        .run();
+    } else if (
+      (bodyParsed.data.action === "completed" || bodyParsed.data.action === "skipped") &&
+      !existing.isRecurring
+    ) {
+      // One-time task completion/skip: mark as done so it drops off the list.
+      const now = new Date().toISOString();
+      db.update(careTasks)
+        .set({ completedAt: now, updatedAt: now })
         .where(eq(careTasks.id, careTaskId))
         .run();
     }
@@ -334,13 +346,8 @@ export async function careTaskRoutes(app: FastifyInstance) {
             .run();
         }
 
-        // If recurring and completed, advance the due date
-        if (
-          action === "completed" &&
-          task.isRecurring &&
-          task.intervalDays &&
-          task.dueDate
-        ) {
+        if (action === "completed" && task.isRecurring && task.intervalDays && task.dueDate) {
+          // Recurring completion: advance due date, task stays active
           const baseDate = new Date(task.dueDate) < new Date() ? new Date() : new Date(task.dueDate);
           const nextDue = new Date(baseDate);
           nextDue.setDate(nextDue.getDate() + task.intervalDays);
@@ -349,6 +356,13 @@ export async function careTaskRoutes(app: FastifyInstance) {
               dueDate: nextDue.toISOString().split("T")[0],
               updatedAt: new Date().toISOString(),
             })
+            .where(eq(careTasks.id, task.id))
+            .run();
+        } else if (!task.isRecurring) {
+          // One-time completion/skip: mark done so it drops off the list
+          const now = new Date().toISOString();
+          tx.update(careTasks)
+            .set({ completedAt: now, updatedAt: now })
             .where(eq(careTasks.id, task.id))
             .run();
         }


### PR DESCRIPTION
## Summary

One-time care tasks (e.g. "Remove pampas", "Call Mt Scott Fuel") were staying in the active list forever after completion. The log row was being inserted, but nothing marked the task itself as done — only recurring tasks dropped off because their `dueDate` advances.

## Changes

- Add `completed_at` column on `care_tasks` (+ index)
- Set it in `POST /care-tasks/:id/log` and `POST /care-tasks/bulk/log` when a non-recurring task is logged as `completed` or `skipped`
- Filter the list query by `completed_at IS NULL` by default; pass `?includeCompleted=true` to include done tasks
- Backfill migration marks existing tasks that already have a completed/skipped log row so the user's current "stuck" tasks drop off immediately after deploy
- MCP `list_care_tasks` tool gains an `include_completed` parameter
- 5 new integration tests for the completion/filter behavior

## Test plan

- [x] `cd server && npx vitest run` — 71/71 passing
- [x] `cd server && npx tsc --noEmit` — clean
- [x] `cd mcp && npx tsc --noEmit` — clean
- [ ] After deploy, verify existing "stuck" tasks (Remove pampas, pruning, Call Mt Scott Fuel) drop off
- [ ] Verify recurring tasks still advance dueDate and stay visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)